### PR TITLE
Use kIOMasterPortDefault const instead of call to IOMasterPort()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Modified from Bootstrap
+
+# Project executable
+osx-cpu-temp
+
+# Numerous always-ignore extensions
+*.diff
+*.err
+*.orig
+*.log
+*.rej
+*.swo
+*.swp
+*.zip
+*.vi
+*~
+
+# OS or Editor folders
+.DS_Store
+._*
+Thumbs.db
+.cache
+.tmproj
+*.esproj
+nbproject
+*.sublime-project
+*.sublime-workspace
+/bin

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Sébastien Lavoie <sebastien@lavoie.sl>
 ### Source 
 
 Apple System Management Control (SMC) Tool 
-Copyright (C) 2006
+Copyright (C) 2006 devnull
 
 ### Inspiration 
 

--- a/smc.c
+++ b/smc.c
@@ -53,14 +53,11 @@ void _ultostr(char *str, UInt32 val)
 kern_return_t SMCOpen(void)
 {
     kern_return_t result;
-    mach_port_t   masterPort;
     io_iterator_t iterator;
     io_object_t   device;
 
-    result = IOMasterPort(MACH_PORT_NULL, &masterPort);
-
     CFMutableDictionaryRef matchingDictionary = IOServiceMatching("AppleSMC");
-    result = IOServiceGetMatchingServices(masterPort, matchingDictionary, &iterator);
+    result = IOServiceGetMatchingServices(kIOMasterPortDefault, matchingDictionary, &iterator);
     if (result != kIOReturnSuccess)
     {
         printf("Error: IOServiceGetMatchingServices() = %08x\n", result);


### PR DESCRIPTION
- Since the default mach port is being used, no need to call **IOMasterPort()**, use
  global constant **kIOMasterPortDefault** instead. See references below
- Add .gitignore for project executable
- Add original Apple SMC tool author name to README
##### References about kIOMasterPortDefault
- [IOKitLib.h](https://developer.apple.com/library/mac/Documentation/IOKit/Reference/IOKitLib_header_reference/Reference/reference.html#//apple_ref/doc/uid/TP40012419-CHIOKitLibhConstants-SW2)
- [Apple Mailing List](http://lists.apple.com/archives/darwin-development/2002/Aug/msg00160.html)
- [OS X and iOS Kernel Programming](http://books.google.ca/books?id=_CUbHkTNXIcC&lpg=PA360&ots=UlxKXGm0Ho&dq=kIOMasterPortDefault&pg=PA73#v=onepage&q=kIOMasterPortDefault&f=false)
