### PR TITLE
Fix accuracy of SMCGetTemperature()

### DIFF
--- a/smc.c
+++ b/smc.c
@@ -154,9 +154,9 @@ double SMCGetTemperature(char *key)
         // read succeeded - check returned value
         if (val.dataSize > 0) {
             if (strcmp(val.dataType, DATATYPE_SP78) == 0) {
-                // convert fp78 value to temperature
-                int intValue = (val.bytes[0] * 256 + val.bytes[1]) >> 2;
-                return intValue / 64.0;
+                // convert sp78 value to temperature
+                int intValue = val.bytes[0] * 256 + (unsigned char)val.bytes[1];
+                return intValue / 256.0;
             }
         }
     }


### PR DESCRIPTION
I tried `osx-cpu-temp` and felt the output unnatural. Sometimes the temperature jumps irregularly.

```
$ while true; do ./osx-cpu-temp ; sleep 1; done
42.1°C
42.0°C
40.9°C
40.8°C
40.5°C
41.4°C
41.2°C
41.0°C
39.9°C
39.8°C
39.6°C
40.4°C
```

It seems to be a bug relating to sign bit. So I added cast from char to unsigned char.