### PR TITLE
Makefile: prefix 'install' with '@'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ $(EXEC) : smc.c
 	$(CC) $(CFLAGS) $(INC) -o $@ $?
 
 install : $(EXEC)
-	install -v $(EXEC) $(PREFIX)/bin/$(EXEC)
+	@install -v $(EXEC) $(PREFIX)/bin/$(EXEC)


### PR DESCRIPTION
- Currently, install output is echo'd twice; once for the command, once for the output of the command
- Prefixing the 'install' command with '@' suppresses the initial echo, leaving just the output
- This works for GNU and POSIX make