### PR TITLE
Print a space between value and unit

### DIFF
--- a/smc.c
+++ b/smc.c
@@ -200,7 +200,7 @@ void readAndPrintCpuTemp(int show_title, char scale) {
     if (show_title) {
         title = "CPU: ";
     }
-    printf("%s%0.1f°%c\n", title, temperature, scale);
+    printf("%s%0.1f °%c\n", title, temperature, scale);
 }
 
 // Requires SMCOpen()
@@ -214,7 +214,7 @@ void readAndPrintGpuTemp(int show_title, char scale) {
     if (show_title) {
         title = "GPU: ";
     }
-    printf("%s%0.1f°%c\n", title, temperature, scale);
+    printf("%s%0.1f °%c\n", title, temperature, scale);
 }
 
 float SMCGetFanRPM(char *key)


### PR DESCRIPTION
The general rule of the International Bureau of Weights and Measures (BIPM) is that the numerical value always precedes the unit, and a space is always used to separate the unit from the number, e.g. "30.2 °C" (not "30.2°C" or "30.2° C").