### PR TITLE
Issue #31 & #32: Change temperatures to PECI

### DIFF
--- a/smc.h
+++ b/smc.h
@@ -39,7 +39,7 @@
 #define DATATYPE_SP78 "sp78"
 
 // key values
-#define SMC_KEY_CPU_TEMP "TC0P"
+#define SMC_KEY_CPU_TEMP "TCXC"
 #define SMC_KEY_GPU_TEMP "TG0P"
 #define SMC_KEY_FAN0_RPM_CUR "F0Ac"
 

--- a/smc.h
+++ b/smc.h
@@ -40,7 +40,7 @@
 
 // key values
 #define SMC_KEY_CPU_TEMP "TCXC"
-#define SMC_KEY_GPU_TEMP "TG0P"
+#define SMC_KEY_GPU_TEMP "TCGC"
 #define SMC_KEY_FAN0_RPM_CUR "F0Ac"
 
 typedef struct {


### PR DESCRIPTION
# Issues related
#31 *GPU Temperature is Broken*
#32 *CPU Temperature is taken from the Proximity Sensor*

# How it was fixed
Used the [PECI](https://wikipedia.org/wiki/Platform_Environment_Control_Interface) values `TCXC` and `TCGC`, instead of CPU Proximity Sensor `TC0P` and GPU Proximity Sensor `TG0P` (broken when tested on `MacBookPro16,2` running `macOS Catalina 10.15.6`).

# How it changes the software
It seems like the PECI values are much more similar to the values of each core, without actually targeting one (the microcontroller takes care of this). After a bit of research, it seems like Intel Power Gadget and macOS are using this value to change their thermals.

# Compatibility
Since PECI is available on all CPUs after the Intel Core 2 Duo, this will only work on devices whose processor was made after. Looking at the MacBook line-up, this means all MacBooks made after the `MacBook2,1` Late 2006 should work.