### PR TITLE
fix: Display of the CPU fan speed on Catalina

### DIFF
--- a/smc.c
+++ b/smc.c
@@ -222,6 +222,10 @@ float SMCGetFanRPM(char* key)
     if (result == kIOReturnSuccess) {
         // read succeeded - check returned value
         if (val.dataSize > 0) {
+            if (strcmp(val.dataType, DATATYPE_FLT) == 0) {
+                return *((float*)val.bytes);
+            }
+
             if (strcmp(val.dataType, DATATYPE_FPE2) == 0) {
                 // convert fpe2 value to RPM
                 return ntohs(*(UInt16*)val.bytes) / 4.0;
@@ -279,7 +283,7 @@ void readAndPrintFanRPMs(void)
             float pct = rpm / (maximum_speed - minimum_speed);
 
             pct *= 100.f;
-            printf("Fan %d - %s at %.0f RPM (%.0f%%)\n", i, name, rpm, pct);
+            printf("Fan %d - %s at %.0f RPM (%.0f%%)\n", i, name, actual_speed, 100*actual_speed/maximum_speed);
 
             //sprintf(key, "F%dSf", i);
             //SMCReadKey(key, &val);

--- a/smc.h
+++ b/smc.h
@@ -32,6 +32,7 @@
 #define SMC_CMD_READ_PLIMIT 11
 #define SMC_CMD_READ_VERS 12
 
+#define DATATYPE_FLT "flt "
 #define DATATYPE_FPE2 "fpe2"
 #define DATATYPE_UINT8 "ui8 "
 #define DATATYPE_UINT16 "ui16"


### PR DESCRIPTION
Hello.
This is a small patch which fixes #28 and adjusts the fan-related output.
Tested on MacBook Air 2020 with Catalina.

I remade the original request from a separate branch to avoid making mess of other changes I did.

Signed-off-by: Alexander Kurbatov Alexander.Kurbatov@acronis.com