### PR TITLE
add options, allow passing SMC key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,25 @@ clib install lavoiesl/osx-cpu-temp
 
 ### Options
 
+ * `-h` Print command line options.
  * `-C` Output temperature in Celsius (default).
  * `-F` Output temperature in Fahrenheit.
+ * `-c [key]` Print CPU temperature, optionally providing the SMC key.
+ * `-g [key]` Print GPU temperature, optionally providing the SMC key.
  * `-f` Output fan speed.
+ * `-t key` Print temperature value of given SMC key.
+ * `-r key` Print raw value of given SMC key.
+ * `-a` Print ALL available SMC keys (without description!).
+
+### Explore keys
+* see https://github.com/acidanthera/VirtualSMC/blob/master/Docs/SMCKeys.txt
+* see https://app.assembla.com/wiki/show/fakesmc
+
+Print the raw value of any key, if it exists
+```shell script
+osx-cpu-temp -r '#KEY' # number of keys
+osx-cpu-temp -r TC0P # CPU proximity sensor
+```
 
 ## Maintainer 
 

--- a/README.md
+++ b/README.md
@@ -38,18 +38,16 @@ clib install lavoiesl/osx-cpu-temp
 ### Options
 
 * Output
-    * `-c` Display CPU temperature (Default).
-    * `-g` Display GPU temperature.
-    * `-a` Display ambient temperature.
-    * `-f` Display fan speeds.
     * `-c [key]` Print CPU temperature, optionally providing the SMC key.
     * `-g [key]` Print GPU temperature, optionally providing the SMC key.
+    * `-a` Display ambient temperature.
+    * `-f` Display fan speeds.
     * `-t key` Print temperature value of given SMC key.
     * `-r key` Print raw value of given SMC key.
 * Format
     * `-C` Display temperatures in degrees Celsius (Default).
     * `-F` Display temperatures in degrees Fahrenheit.
-   * `-T` Do not display the units for temperatures.
+    * `-T` Do not display the units for temperatures.
 
 ### Explore keys
 * see https://github.com/acidanthera/VirtualSMC/blob/master/Docs/SMCKeys.txt

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Outputs current CPU temperature for OSX.
 
-## Usage 
+## Usage
 
 ### Compiling
 
@@ -37,15 +37,15 @@ clib install lavoiesl/osx-cpu-temp
 
 ### Options
 
- * `-h` Print command line options.
- * `-C` Output temperature in Celsius (default).
- * `-F` Output temperature in Fahrenheit.
- * `-c [key]` Print CPU temperature, optionally providing the SMC key.
- * `-g [key]` Print GPU temperature, optionally providing the SMC key.
- * `-f` Output fan speed.
- * `-t key` Print temperature value of given SMC key.
- * `-r key` Print raw value of given SMC key.
- * `-a` Print ALL available SMC keys (without description!).
+* Output
+    * `-c` Display CPU temperature (Default).
+    * `-g` Display GPU temperature.
+    * `-a` Display ambient temperature.
+    * `-f` Display fan speeds.
+* Format
+    * `-C` Display temperatures in degrees Celsius (Default).
+    * `-F` Display temperatures in degrees Fahrenheit.
+    * `-T` Do not display the units for temperatures.
 
 ### Explore keys
 * see https://github.com/acidanthera/VirtualSMC/blob/master/Docs/SMCKeys.txt
@@ -57,16 +57,16 @@ osx-cpu-temp -r '#KEY' # number of keys
 osx-cpu-temp -r TC0P # CPU proximity sensor
 ```
 
-## Maintainer 
+## Maintainer
 
 Sébastien Lavoie <github@lavoie.sl>
 
-### Source 
+### Source
 
-Apple System Management Control (SMC) Tool 
+Apple System Management Control (SMC) Tool
 Copyright (C) 2006
 
-### Inspiration 
+### Inspiration
 
  * https://www.eidac.de/smcfancontrol/
  * https://github.com/hholtmann/smcFanControl/tree/master/smc-command

--- a/README.md
+++ b/README.md
@@ -42,10 +42,24 @@ clib install lavoiesl/osx-cpu-temp
     * `-g` Display GPU temperature.
     * `-a` Display ambient temperature.
     * `-f` Display fan speeds.
+    * `-c [key]` Print CPU temperature, optionally providing the SMC key.
+    * `-g [key]` Print GPU temperature, optionally providing the SMC key.
+    * `-t key` Print temperature value of given SMC key.
+    * `-r key` Print raw value of given SMC key.
 * Format
     * `-C` Display temperatures in degrees Celsius (Default).
     * `-F` Display temperatures in degrees Fahrenheit.
-    * `-T` Do not display the units for temperatures.
+   * `-T` Do not display the units for temperatures.
+
+### Explore keys
+* see https://github.com/acidanthera/VirtualSMC/blob/master/Docs/SMCKeys.txt
+* see https://app.assembla.com/wiki/show/fakesmc
+
+Print the raw value of any key, if it exists
+```shell script
+osx-cpu-temp -r '#KEY' # number of keys
+osx-cpu-temp -r TC0P # CPU proximity sensor
+```
 
 ### Explore keys
 * see https://github.com/acidanthera/VirtualSMC/blob/master/Docs/SMCKeys.txt

--- a/smc.c
+++ b/smc.c
@@ -143,7 +143,7 @@ UInt32 SMCReadIndexCount(void)
     SMCVal_t val;
 
     SMCReadKey("#KEY", &val);
-    return _strtoul((char *)val.bytes, val.dataSize, 10);
+    return _strtoul((char*)val.bytes, val.dataSize, 10);
 }
 
 double SMCNormalizeFloat(SMCVal_t val)
@@ -166,7 +166,7 @@ double SMCNormalizeFloat(SMCVal_t val)
 int SMCNormalizeInt(SMCVal_t val)
 {
     if (strcmp(val.dataType, DATATYPE_UINT8) == 0 || strcmp(val.dataType, DATATYPE_UINT16) == 0 || strcmp(val.dataType, DATATYPE_UINT32) == 0) {
-        return (int) _strtoul((char *)val.bytes, val.dataSize, 10);
+        return (int)_strtoul((char*)val.bytes, val.dataSize, 10);
     }
     if (strcmp(val.dataType, DATATYPE_SI16) == 0) {
         return ntohs(*(SInt16*)val.bytes);
@@ -176,9 +176,9 @@ int SMCNormalizeInt(SMCVal_t val)
         printf("Hex value = 0x");
         int i;
         for (i = 0; i < val.dataSize; i++)
-          printf("%02x ", (unsigned char) val.bytes[i]);
+            printf("%02x ", (unsigned char)val.bytes[i]);
         printf("\n");
-        return (int) _strtoul((char *)val.bytes, val.dataSize, 10);
+        return (int)_strtoul((char*)val.bytes, val.dataSize, 10);
     }
     return -1;
 }
@@ -191,7 +191,7 @@ char* SMCNormalizeText(SMCVal_t val)
         for (i = 0; i < val.dataSize; i++) {
             result[i] = (unsigned char)val.bytes[i];
         }
-        result[i+1] = 0;
+        result[i + 1] = 0;
         return strdup(result);
     }
 
@@ -213,18 +213,17 @@ char* SMCNormalizeText(SMCVal_t val)
 kern_return_t SMCPrintAll(void)
 {
     kern_return_t result;
-    SMCKeyData_t  inputStructure;
-    SMCKeyData_t  outputStructure;
+    SMCKeyData_t inputStructure;
+    SMCKeyData_t outputStructure;
 
-    int           totalKeys, i;
-    UInt32Char_t  key;
-    SMCVal_t      val;
+    int totalKeys, i;
+    UInt32Char_t key;
+    SMCVal_t val;
 
     totalKeys = SMCReadIndexCount();
     printf("Total keys = %d\n", totalKeys);
 
-    for (i = 0; i < totalKeys; i++)
-    {
+    for (i = 0; i < totalKeys; i++) {
         memset(&inputStructure, 0, sizeof(SMCKeyData_t));
         memset(&outputStructure, 0, sizeof(SMCKeyData_t));
         memset(&val, 0, sizeof(SMCVal_t));
@@ -238,9 +237,9 @@ kern_return_t SMCPrintAll(void)
 
         _ultostr(key, outputStructure.key);
 
-		SMCReadKey(key, &val);
-		char* txt = SMCNormalizeText(val);
-		printf("key = %s type = %s value = %s\n", key, val.dataType, txt);
+        SMCReadKey(key, &val);
+        char* txt = SMCNormalizeText(val);
+        printf("key = %s type = %s value = %s\n", key, val.dataType, txt);
     }
 
     return kIOReturnSuccess;

--- a/smc.c
+++ b/smc.c
@@ -1,6 +1,6 @@
 /*
- * Apple System Management Control (SMC) Tool 
- * Copyright (C) 2006 devnull 
+ * Apple System Management Control (SMC) Tool
+ * Copyright (C) 2006 devnull
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -56,7 +56,7 @@ kern_return_t SMCOpen(void)
     io_object_t device;
 
     CFMutableDictionaryRef matchingDictionary = IOServiceMatching("AppleSMC");
-    result = IOServiceGetMatchingServices(kIOMasterPortDefault, matchingDictionary, &iterator);
+    result = IOServiceGetMatchingServices(kIOMainPortDefault, matchingDictionary, &iterator);
     if (result != kIOReturnSuccess) {
         printf("Error: IOServiceGetMatchingServices() = %08x\n", result);
         return 1;

--- a/smc.c
+++ b/smc.c
@@ -485,6 +485,9 @@ int main(int argc, char* argv[])
                 return -1;
             }
             break;
+        case 'a':
+            amb = true;
+            break;
         case 'h':
         case '?':
             printf("usage: osx-cpu-temp <options>\n");
@@ -509,7 +512,7 @@ int main(int argc, char* argv[])
         cpu = 1;
     }
 
-    bool show_title = fan + gpu + cpu > 1;
+    bool show_title = fan + gpu + cpu + amb > 1;
 
     SMCOpen();
 
@@ -518,6 +521,9 @@ int main(int argc, char* argv[])
     }
     if (gpu) {
         readAndPrintTemperature("GPU: ", show_title, SMC_KEY_GPU_TEMP, scale, show_scale);
+    }
+    if (amb) {
+        readAndPrintTemperature("Ambient: ", show_title, SMC_KEY_AMBIENT_TEMP, scale, show_scale);
     }
     if (fan) {
         readAndPrintFanRPMs();

--- a/smc.c
+++ b/smc.c
@@ -138,7 +138,12 @@ kern_return_t SMCReadKey(UInt32Char_t key, SMCVal_t* val)
     return kIOReturnSuccess;
 }
 
+<<<<<<< HEAD
 UInt32 SMCReadIndexCount(void)
+=======
+// Requires SMCOpen()
+double SMCGetTemperature(char* key)
+>>>>>>> 180cff1 (Refactor readAndPrintTemperature)
 {
     kern_return_t result;
     SMCVal_t val;
@@ -150,6 +155,7 @@ UInt32 SMCReadIndexCount(void)
     return _strtoul((char*)val.bytes, val.dataSize, 10);
 }
 
+<<<<<<< HEAD
 double SMCNormalizeFloat(SMCVal_t val)
 {
     if (strcmp(val.dataType, DATATYPE_SP78) == 0) {
@@ -253,6 +259,10 @@ kern_return_t SMCPrintAll(void)
 }
 
 double SMCGetDouble(char* key)
+=======
+// Requires SMCOpen()
+double SMCGetFanSpeed(char* key)
+>>>>>>> 180cff1 (Refactor readAndPrintTemperature)
 {
     SMCVal_t val;
     kern_return_t result;
@@ -273,21 +283,38 @@ double convertToFahrenheit(double celsius)
     return (celsius * (9.0 / 5.0)) + 32.0;
 }
 
+<<<<<<< HEAD
 // Requires SMCOpen()
 void readAndPrintCpuTemp(char* key, int show_title, char scale)
 {
     double temperature = SMCGetDouble(key);
+=======
+double readTemperature(char* key, char scale)
+{
+    double temperature = SMCGetTemperature(key);
+>>>>>>> 180cff1 (Refactor readAndPrintTemperature)
     if (scale == 'F') {
         temperature = convertToFahrenheit(temperature);
     }
+    return temperature;
+}
 
+void readAndPrintTemperature(char* title, char* key, char scale)
+{
+    double temperature = readTemperature(key, scale);
+    printf("%s%0.1f °%c\n", title, temperature, scale);
+}
+
+void readAndPrintCpuTemp(bool show_title, char scale)
+{
     char* title = "";
     if (show_title) {
         title = "CPU: ";
     }
-    printf("%s%0.1f °%c\n", title, temperature, scale);
+    readAndPrintTemperature(title, SMC_KEY_CPU_TEMP, scale);
 }
 
+<<<<<<< HEAD
 // Requires SMCOpen()
 void readAndPrintGpuTemp(char* key, int show_title, char scale)
 {
@@ -296,11 +323,15 @@ void readAndPrintGpuTemp(char* key, int show_title, char scale)
         temperature = convertToFahrenheit(temperature);
     }
 
+=======
+void readAndPrintGpuTemp(bool show_title, char scale)
+{
+>>>>>>> 180cff1 (Refactor readAndPrintTemperature)
     char* title = "";
     if (show_title) {
         title = "GPU: ";
     }
-    printf("%s%0.1f °%c\n", title, temperature, scale);
+    readAndPrintTemperature(title, SMC_KEY_GPU_TEMP, scale);
 }
 
 // Requires SMCOpen()
@@ -447,7 +478,7 @@ int main(int argc, char* argv[])
             key = optarg;
             break;
         case 'f':
-            fan = 1;
+            fan = true;
             break;
         case 't':
             tmp = 1;
@@ -458,7 +489,7 @@ int main(int argc, char* argv[])
             key = optarg;
             break;
         // all option, see: https://github.com/hholtmann/smcFanControl/blob/875c68b0d36fbda40d2bf745fc43dcb40523360b/smc-command/smc.c#L485
-        case 'a':
+        case 'A':
             all = 1;
             break;
         case ':':
@@ -483,9 +514,11 @@ int main(int argc, char* argv[])
             printf("  -C       Display temperatures in degrees Celsius (Default).\n");
             printf("  -c [key] Display CPU temperature [of given key] (Default).\n");
             printf("  -g [key] Display GPU temperature [of given key].\n");
+            printf("  -a       Display ambient temperature.\n");
             printf("  -f       Display fan speeds.\n");
             printf("  -t key   Display temperature of given SMC key.\n");
             printf("  -r key   Display raw value of given SMC key.\n");
+            printf("  -A       Display ALL SMC keys\n")
             printf("  -h       Display this help.\n");
             printf("\nIf more than one of -c, -f, or -g are specified, titles will be added\n");
             return -1;
@@ -496,7 +529,7 @@ int main(int argc, char* argv[])
         cpu = 1;
     }
 
-    int show_title = fan + gpu + cpu > 1;
+    bool show_title = fan + gpu + cpu > 1;
 
     SMCOpen();
 

--- a/smc.c
+++ b/smc.c
@@ -138,12 +138,8 @@ kern_return_t SMCReadKey(UInt32Char_t key, SMCVal_t* val)
     return kIOReturnSuccess;
 }
 
-<<<<<<< HEAD
-UInt32 SMCReadIndexCount(void)
-=======
 // Requires SMCOpen()
 double SMCGetTemperature(char* key)
->>>>>>> 180cff1 (Refactor readAndPrintTemperature)
 {
     kern_return_t result;
     SMCVal_t val;
@@ -155,7 +151,6 @@ double SMCGetTemperature(char* key)
     return _strtoul((char*)val.bytes, val.dataSize, 10);
 }
 
-<<<<<<< HEAD
 double SMCNormalizeFloat(SMCVal_t val)
 {
     if (strcmp(val.dataType, DATATYPE_SP78) == 0) {
@@ -259,10 +254,6 @@ kern_return_t SMCPrintAll(void)
 }
 
 double SMCGetDouble(char* key)
-=======
-// Requires SMCOpen()
-double SMCGetFanSpeed(char* key)
->>>>>>> 180cff1 (Refactor readAndPrintTemperature)
 {
     SMCVal_t val;
     kern_return_t result;
@@ -283,50 +274,34 @@ double convertToFahrenheit(double celsius)
     return (celsius * (9.0 / 5.0)) + 32.0;
 }
 
-<<<<<<< HEAD
-// Requires SMCOpen()
-void readAndPrintCpuTemp(char* key, int show_title, char scale)
-{
-    double temperature = SMCGetDouble(key);
-=======
 double readTemperature(char* key, char scale)
 {
     double temperature = SMCGetTemperature(key);
->>>>>>> 180cff1 (Refactor readAndPrintTemperature)
     if (scale == 'F') {
         temperature = convertToFahrenheit(temperature);
     }
     return temperature;
 }
 
-void readAndPrintTemperature(char* title, char* key, char scale)
+void readAndPrintTemperature(char* title, bool show_title, char* key, char scale, bool show_scale)
 {
-    double temperature = readTemperature(key, scale);
-    printf("%s%0.1f °%c\n", title, temperature, scale);
-}
-
-void readAndPrintCpuTemp(bool show_title, char scale)
-{
-    char* title = "";
-    if (show_title) {
-        title = "CPU: ";
+    if (!show_title) {
+        title = "";
     }
+
+    double temperature = readTemperature(key, scale);
+
+    if (show_scale) {
+        printf("%s%0.1f °%c\n", title, temperature, scale);
+    } else {
+        printf("%s%0.1f\n", title, temperature);
+    }
+<<<<<<< HEAD
     readAndPrintTemperature(title, SMC_KEY_CPU_TEMP, scale);
 }
 
-<<<<<<< HEAD
-// Requires SMCOpen()
-void readAndPrintGpuTemp(char* key, int show_title, char scale)
-{
-    double temperature = SMCGetDouble(key);
-    if (scale == 'F') {
-        temperature = convertToFahrenheit(temperature);
-    }
-
-=======
 void readAndPrintGpuTemp(bool show_title, char scale)
 {
->>>>>>> 180cff1 (Refactor readAndPrintTemperature)
     char* title = "";
     if (show_title) {
         title = "GPU: ";
@@ -452,6 +427,7 @@ void readAndPrintAll(void)
 int main(int argc, char* argv[])
 {
     char scale = 'C';
+    bool show_scale = true;
     int cpu = 0;
     int fan = 0;
     int gpu = 0;
@@ -461,11 +437,14 @@ int main(int argc, char* argv[])
     char* key;
 
     int c;
-    while ((c = getopt(argc, argv, ":CFc:g:ft:r:ah?")) != -1) {
+    while ((c = getopt(argc, argv, ":CFc:g:ft:r:aAh?")) != -1) {
         switch (c) {
         case 'F':
         case 'C':
             scale = c;
+            break;
+        case 'T':
+            show_scale = false;
             break;
         case 'c':
             // optionally allow to pass the SMC Key (**TC0P**, TC0D, TCXC, ...)
@@ -512,6 +491,7 @@ int main(int argc, char* argv[])
             printf("Options:\n");
             printf("  -F       Display temperatures in degrees Fahrenheit.\n");
             printf("  -C       Display temperatures in degrees Celsius (Default).\n");
+            printf("  -T       Do not display the units for temperatures.\n");
             printf("  -c [key] Display CPU temperature [of given key] (Default).\n");
             printf("  -g [key] Display GPU temperature [of given key].\n");
             printf("  -a       Display ambient temperature.\n");
@@ -534,10 +514,10 @@ int main(int argc, char* argv[])
     SMCOpen();
 
     if (cpu) {
-        readAndPrintCpuTemp(key, show_title, scale);
+        readAndPrintTemperature("CPU: ", show_title, SMC_KEY_CPU_TEMP, scale, show_scale);
     }
     if (gpu) {
-        readAndPrintGpuTemp(key, show_title, scale);
+        readAndPrintTemperature("GPU: ", show_title, SMC_KEY_GPU_TEMP, scale, show_scale);
     }
     if (fan) {
         readAndPrintFanRPMs();

--- a/smc.c
+++ b/smc.c
@@ -32,9 +32,9 @@ UInt32 _strtoul(char* str, int size, int base)
 
     for (i = 0; i < size; i++) {
         if (base == 16)
-            total += str[i] << (size - 1 - i) * 8;
+            total += (str[i] << (size - 1 - i) * 8);
         else
-            total += (unsigned char)(str[i] << (size - 1 - i) * 8);
+            total += ((unsigned char)(str[i]) << (size - 1 - i) * 8);
     }
     return total;
 }
@@ -138,6 +138,114 @@ kern_return_t SMCReadKey(UInt32Char_t key, SMCVal_t* val)
     return kIOReturnSuccess;
 }
 
+UInt32 SMCReadIndexCount(void)
+{
+    SMCVal_t val;
+
+    SMCReadKey("#KEY", &val);
+    return _strtoul((char *)val.bytes, val.dataSize, 10);
+}
+
+double SMCNormalizeFloat(SMCVal_t val)
+{
+    if (strcmp(val.dataType, DATATYPE_SP78) == 0) {
+        return ((SInt16)ntohs(*(UInt16*)val.bytes)) / 256.0;
+    }
+    if (strcmp(val.dataType, DATATYPE_SP5A) == 0) {
+        return ((SInt16)ntohs(*(UInt16*)val.bytes)) / 1024.0;
+    }
+    if (strcmp(val.dataType, DATATYPE_FPE2) == 0) {
+        return ntohs(*(UInt16*)val.bytes) / 4.0;
+    }
+    if (strcmp(val.dataType, DATATYPE_FP88) == 0) {
+        return ntohs(*(UInt16*)val.bytes) / 256.0;
+    }
+    return -1.f;
+}
+
+int SMCNormalizeInt(SMCVal_t val)
+{
+    if (strcmp(val.dataType, DATATYPE_UINT8) == 0 || strcmp(val.dataType, DATATYPE_UINT16) == 0 || strcmp(val.dataType, DATATYPE_UINT32) == 0) {
+        return (int) _strtoul((char *)val.bytes, val.dataSize, 10);
+    }
+    if (strcmp(val.dataType, DATATYPE_SI16) == 0) {
+        return ntohs(*(SInt16*)val.bytes);
+    }
+
+    if (strcmp(val.dataType, DATATYPE_HEX) == 0 || strcmp(val.dataType, DATATYPE_FLAG) == 0) {
+        printf("Hex value = 0x");
+        int i;
+        for (i = 0; i < val.dataSize; i++)
+          printf("%02x ", (unsigned char) val.bytes[i]);
+        printf("\n");
+        return (int) _strtoul((char *)val.bytes, val.dataSize, 10);
+    }
+    return -1;
+}
+
+char* SMCNormalizeText(SMCVal_t val)
+{
+    char result[val.dataSize + 2];
+    if (strcmp(val.dataType, DATATYPE_CH8) == 0) {
+        int i;
+        for (i = 0; i < val.dataSize; i++) {
+            result[i] = (unsigned char)val.bytes[i];
+        }
+        result[i+1] = 0;
+        return strdup(result);
+    }
+
+    // convert anything else to text
+    double f = SMCNormalizeFloat(val);
+    if (f != -1.0) {
+        snprintf(result, 10, "%0.1f", f);
+        return strdup(result);
+    }
+    int i = SMCNormalizeInt(val);
+    if (i != -1) {
+        snprintf(result, 10, "%d", i);
+        return strdup(result);
+    }
+
+    return strdup(result);
+}
+
+kern_return_t SMCPrintAll(void)
+{
+    kern_return_t result;
+    SMCKeyData_t  inputStructure;
+    SMCKeyData_t  outputStructure;
+
+    int           totalKeys, i;
+    UInt32Char_t  key;
+    SMCVal_t      val;
+
+    totalKeys = SMCReadIndexCount();
+    printf("Total keys = %d\n", totalKeys);
+
+    for (i = 0; i < totalKeys; i++)
+    {
+        memset(&inputStructure, 0, sizeof(SMCKeyData_t));
+        memset(&outputStructure, 0, sizeof(SMCKeyData_t));
+        memset(&val, 0, sizeof(SMCVal_t));
+
+        inputStructure.data8 = SMC_CMD_READ_INDEX;
+        inputStructure.data32 = i;
+
+        result = SMCCall(KERNEL_INDEX_SMC, &inputStructure, &outputStructure);
+        if (result != kIOReturnSuccess)
+            continue;
+
+        _ultostr(key, outputStructure.key);
+
+		SMCReadKey(key, &val);
+		char* txt = SMCNormalizeText(val);
+		printf("key = %s type = %s value = %s\n", key, val.dataType, txt);
+    }
+
+    return kIOReturnSuccess;
+}
+
 double SMCGetTemperature(char* key)
 {
     SMCVal_t val;
@@ -147,15 +255,11 @@ double SMCGetTemperature(char* key)
     if (result == kIOReturnSuccess) {
         // read succeeded - check returned value
         if (val.dataSize > 0) {
-            if (strcmp(val.dataType, DATATYPE_SP78) == 0) {
-                // convert sp78 value to temperature
-                int intValue = val.bytes[0] * 256 + (unsigned char)val.bytes[1];
-                return intValue / 256.0;
-            }
+            return SMCNormalizeFloat(val);
         }
     }
     // read failed
-    return 0.0;
+    return -1.0;
 }
 
 double SMCGetFanSpeed(char* key)
@@ -167,15 +271,43 @@ double SMCGetFanSpeed(char* key)
     if (result == kIOReturnSuccess) {
         // read succeeded - check returned value
         if (val.dataSize > 0) {
-            if (strcmp(val.dataType, DATATYPE_FPE2) == 0) {
-                // convert fpe2 value to rpm
-                int intValue = (unsigned char)val.bytes[0] * 256 + (unsigned char)val.bytes[1];
-                return intValue / 4.0;
-            }
+            return SMCNormalizeFloat(val);
         }
     }
     // read failed
-    return 0.0;
+    return -1.0;
+}
+
+float SMCGetFanRPM(char* key)
+{
+    SMCVal_t val;
+    kern_return_t result;
+
+    result = SMCReadKey(key, &val);
+    if (result == kIOReturnSuccess) {
+        // read succeeded - check returned value
+        if (val.dataSize > 0) {
+            return SMCNormalizeFloat(val);
+        }
+    }
+    // read failed
+    return -1.f;
+}
+
+double SMCGetPower(char* key)
+{
+    SMCVal_t val;
+    kern_return_t result;
+
+    result = SMCReadKey(key, &val);
+    if (result == kIOReturnSuccess) {
+        // read succeeded - check returned value
+        if (val.dataSize > 0) {
+            return SMCNormalizeFloat(val);
+        }
+    }
+    // read failed
+    return -1.f;
 }
 
 double convertToFahrenheit(double celsius)
@@ -184,9 +316,9 @@ double convertToFahrenheit(double celsius)
 }
 
 // Requires SMCOpen()
-void readAndPrintCpuTemp(int show_title, char scale)
+void readAndPrintCpuTemp(char* key, int show_title, char scale)
 {
-    double temperature = SMCGetTemperature(SMC_KEY_CPU_TEMP);
+    double temperature = SMCGetTemperature(key);
     if (scale == 'F') {
         temperature = convertToFahrenheit(temperature);
     }
@@ -199,9 +331,9 @@ void readAndPrintCpuTemp(int show_title, char scale)
 }
 
 // Requires SMCOpen()
-void readAndPrintGpuTemp(int show_title, char scale)
+void readAndPrintGpuTemp(char* key, int show_title, char scale)
 {
-    double temperature = SMCGetTemperature(SMC_KEY_GPU_TEMP);
+    double temperature = SMCGetTemperature(key);
     if (scale == 'F') {
         temperature = convertToFahrenheit(temperature);
     }
@@ -213,23 +345,46 @@ void readAndPrintGpuTemp(int show_title, char scale)
     printf("%s%0.1f °%c\n", title, temperature, scale);
 }
 
-float SMCGetFanRPM(char* key)
+// Requires SMCOpen()
+void readAndPrintTemp(char* key, char scale)
+{
+    double temperature = SMCGetTemperature(key);
+    if (scale == 'F') {
+        temperature = convertToFahrenheit(temperature);
+    }
+    printf("%s = %0.1f °%c\n", key, temperature, scale);
+}
+
+// Requires SMCOpen()
+void readAndPrintRawValue(char* key)
 {
     SMCVal_t val;
     kern_return_t result;
+    float f;
+    int i;
+    char* c;
 
     result = SMCReadKey(key, &val);
     if (result == kIOReturnSuccess) {
         // read succeeded - check returned value
         if (val.dataSize > 0) {
-            if (strcmp(val.dataType, DATATYPE_FPE2) == 0) {
-                // convert fpe2 value to RPM
-                return ntohs(*(UInt16*)val.bytes) / 4.0;
+            f = SMCNormalizeFloat(val);
+            if (f != -1.0) {
+                printf("%s = %0.1f\n", key, f);
+                return;
+            }
+            i = SMCNormalizeInt(val);
+            if (i != -1) {
+                printf("%s = %d\n", key, i);
+                return;
+            }
+            c = SMCNormalizeText(val);
+            if (strcmp(c, "") != 0) {
+                printf("%s = %s\n", key, c);
+                return;
             }
         }
     }
-    // read failed
-    return -1.f;
 }
 
 // Requires SMCOpen()
@@ -243,7 +398,7 @@ void readAndPrintFanRPMs(void)
     result = SMCReadKey("FNum", &val);
 
     if (result == kIOReturnSuccess) {
-        totalFans = _strtoul((char*)val.bytes, val.dataSize, 10);
+        totalFans = SMCNormalizeInt(val);
 
         printf("Num fans: %d\n", totalFans);
         for (i = 0; i < totalFans; i++) {
@@ -296,45 +451,90 @@ void readAndPrintFanRPMs(void)
     }
 }
 
+void readAndPrintAll(void)
+{
+    kern_return_t result;
+    result = SMCPrintAll();
+    if (result != kIOReturnSuccess) {
+        printf("Error reading keys: %d", result);
+    }
+}
+
 int main(int argc, char* argv[])
 {
     char scale = 'C';
     int cpu = 0;
     int fan = 0;
     int gpu = 0;
+    int tmp = 0;
+    int raw = 0;
+    int all = 0;
+    char* key;
 
     int c;
-    while ((c = getopt(argc, argv, "CFcfgh?")) != -1) {
+    while ((c = getopt(argc, argv, ":CFc:g:ft:r:ah?")) != -1) {
         switch (c) {
         case 'F':
         case 'C':
             scale = c;
             break;
         case 'c':
+            // optionally allow to pass the SMC Key (**TC0P**, TC0D, TCXC, ...)
             cpu = 1;
+            key = optarg;
+            break;
+        case 'g':
+            // optionally allow to pass the SMC Key (**TG0P**, TG0D, TCGC, ...)
+            gpu = 1;
+            key = optarg;
             break;
         case 'f':
             fan = 1;
             break;
-        case 'g':
-            gpu = 1;
+        case 't':
+            tmp = 1;
+            key = optarg;
+            break;
+        case 'r':
+            raw = 1;
+            key = optarg;
+            break;
+        // all option, see: https://github.com/hholtmann/smcFanControl/blob/875c68b0d36fbda40d2bf745fc43dcb40523360b/smc-command/smc.c#L485
+        case 'a':
+            all = 1;
+            break;
+        case ':':
+            // optional arguments, set defaults
+            switch (optopt) {
+            case 'c':
+                key = SMC_KEY_CPU_TEMP;
+                break;
+            case 'g':
+                key = SMC_KEY_GPU_TEMP;
+                break;
+            default:
+                printf("Error: '-%c' requires an argument", optopt);
+                return -1;
+            }
             break;
         case 'h':
         case '?':
             printf("usage: osx-cpu-temp <options>\n");
             printf("Options:\n");
-            printf("  -F  Display temperatures in degrees Fahrenheit.\n");
-            printf("  -C  Display temperatures in degrees Celsius (Default).\n");
-            printf("  -c  Display CPU temperature (Default).\n");
-            printf("  -g  Display GPU temperature.\n");
-            printf("  -f  Display fan speeds.\n");
-            printf("  -h  Display this help.\n");
+            printf("  -F     Display temperatures in degrees Fahrenheit.\n");
+            printf("  -C     Display temperatures in degrees Celsius (Default).\n");
+            printf("  -c     Display CPU temperature (Default).\n");
+            printf("  -g     Display GPU temperature.\n");
+            printf("  -f     Display fan speeds.\n");
+            printf("  -t key Display temperature of given SMC key");
+            printf("  -r key Display raw value of given SMC key");
+            printf("  -h     Display this help.\n");
             printf("\nIf more than one of -c, -f, or -g are specified, titles will be added\n");
             return -1;
         }
     }
 
-    if (!fan && !gpu) {
+    if (!fan && !gpu && !tmp && !raw & !all) {
         cpu = 1;
     }
 
@@ -343,13 +543,22 @@ int main(int argc, char* argv[])
     SMCOpen();
 
     if (cpu) {
-        readAndPrintCpuTemp(show_title, scale);
+        readAndPrintCpuTemp(key, show_title, scale);
     }
     if (gpu) {
-        readAndPrintGpuTemp(show_title, scale);
+        readAndPrintGpuTemp(key, show_title, scale);
     }
     if (fan) {
         readAndPrintFanRPMs();
+    }
+    if (tmp) {
+        readAndPrintTemp(key, scale);
+    }
+    if (raw) {
+        readAndPrintRawValue(key);
+    }
+    if (all) {
+        readAndPrintAll();
     }
 
     SMCClose();

--- a/smc.c
+++ b/smc.c
@@ -140,6 +140,7 @@ kern_return_t SMCReadKey(UInt32Char_t key, SMCVal_t* val)
 
 UInt32 SMCReadIndexCount(void)
 {
+    kern_return_t result;
     SMCVal_t val;
 
     SMCReadKey("#KEY", &val);
@@ -413,6 +414,8 @@ double SMCGetPower(char* key)
     return -1.f;
 }
 
+=======
+>>>>>>> ef86749 (resolve conflicts)
 double convertToFahrenheit(double celsius)
 {
     return (celsius * (9.0 / 5.0)) + 32.0;
@@ -420,7 +423,7 @@ double convertToFahrenheit(double celsius)
 
 double readTemperature(char* key, char scale)
 {
-    double temperature = SMCGetTemperature(key);
+    double temperature = SMCGetDouble(key);
     if (scale == 'F') {
         temperature = convertToFahrenheit(temperature);
     }
@@ -429,8 +432,9 @@ double readTemperature(char* key, char scale)
 
 void readAndPrintTemperature(char* title, bool show_title, char* key, char scale, bool show_scale)
 {
-    if (!show_title) {
-        title = "";
+    double temperature = SMCGetDouble(key);
+    if (scale == 'F') {
+        temperature = convertToFahrenheit(temperature);
     }
 
     double temperature = readTemperature(key, scale);

--- a/smc.c
+++ b/smc.c
@@ -521,14 +521,14 @@ int main(int argc, char* argv[])
         case '?':
             printf("usage: osx-cpu-temp <options>\n");
             printf("Options:\n");
-            printf("  -F     Display temperatures in degrees Fahrenheit.\n");
-            printf("  -C     Display temperatures in degrees Celsius (Default).\n");
-            printf("  -c     Display CPU temperature (Default).\n");
-            printf("  -g     Display GPU temperature.\n");
-            printf("  -f     Display fan speeds.\n");
-            printf("  -t key Display temperature of given SMC key");
-            printf("  -r key Display raw value of given SMC key");
-            printf("  -h     Display this help.\n");
+            printf("  -F       Display temperatures in degrees Fahrenheit.\n");
+            printf("  -C       Display temperatures in degrees Celsius (Default).\n");
+            printf("  -c [key] Display CPU temperature [of given key] (Default).\n");
+            printf("  -g [key] Display GPU temperature [of given key].\n");
+            printf("  -f       Display fan speeds.\n");
+            printf("  -t key   Display temperature of given SMC key");
+            printf("  -r key   Display raw value of given SMC key");
+            printf("  -h       Display this help.\n");
             printf("\nIf more than one of -c, -f, or -g are specified, titles will be added\n");
             return -1;
         }

--- a/smc.c
+++ b/smc.c
@@ -484,8 +484,8 @@ int main(int argc, char* argv[])
             printf("  -c [key] Display CPU temperature [of given key] (Default).\n");
             printf("  -g [key] Display GPU temperature [of given key].\n");
             printf("  -f       Display fan speeds.\n");
-            printf("  -t key   Display temperature of given SMC key");
-            printf("  -r key   Display raw value of given SMC key");
+            printf("  -t key   Display temperature of given SMC key.\n");
+            printf("  -r key   Display raw value of given SMC key.\n");
             printf("  -h       Display this help.\n");
             printf("\nIf more than one of -c, -f, or -g are specified, titles will be added\n");
             return -1;

--- a/smc.c
+++ b/smc.c
@@ -414,8 +414,6 @@ double SMCGetPower(char* key)
     return -1.f;
 }
 
-=======
->>>>>>> ef86749 (resolve conflicts)
 double convertToFahrenheit(double celsius)
 {
     return (celsius * (9.0 / 5.0)) + 32.0;
@@ -646,9 +644,9 @@ int main(int argc, char* argv[])
             printf("  -g [key] Display GPU temperature [of given key].\n");
             printf("  -a       Display ambient temperature.\n");
             printf("  -f       Display fan speeds.\n");
-            printf("  -t key   Display temperature of given SMC key.\n");
-            printf("  -r key   Display raw value of given SMC key.\n");
-            printf("  -A       Display ALL SMC keys\n")
+            printf("  -A       Display all SMC keys")
+            printf("  -t key   Display temperature of given SMC key\n");
+            printf("  -r key   Display raw value of given SMC key\n");
             printf("  -h       Display this help.\n");
             printf("\nIf more than one of -c, -f, or -g are specified, titles will be added\n");
             return -1;

--- a/smc.c
+++ b/smc.c
@@ -327,6 +327,10 @@ double readTemperature(char* key, char scale)
 
 void readAndPrintTemperature(char* title, bool show_title, char* key, char scale, bool show_scale)
 {
+    if (!show_title) {
+         title = "";
+    }
+
     double temperature = readTemperature(key, scale);
 
     if (show_scale) {

--- a/smc.c
+++ b/smc.c
@@ -241,7 +241,10 @@ kern_return_t SMCPrintAll(void)
 
         _ultostr(key, outputStructure.key);
 
-        SMCReadKey(key, &val);
+        result = SMCReadKey(key, &val);
+        if (result != kIOReturnSuccess)
+            continue;
+
         char* txt = SMCNormalizeText(val);
         printf("key = %s type = %s value = %s\n", key, val.dataType, txt);
     }

--- a/smc.h
+++ b/smc.h
@@ -33,10 +33,16 @@
 #define SMC_CMD_READ_VERS 12
 
 #define DATATYPE_FPE2 "fpe2"
+#define DATATYPE_FP88 "fp88"
 #define DATATYPE_UINT8 "ui8 "
 #define DATATYPE_UINT16 "ui16"
 #define DATATYPE_UINT32 "ui32"
 #define DATATYPE_SP78 "sp78"
+#define DATATYPE_SP5A "sp5a"
+#define DATATYPE_SI16 "si16"
+#define DATATYPE_HEX "hex_"
+#define DATATYPE_FLAG "flag"
+#define DATATYPE_CH8 "ch8*"
 
 // key values
 #define SMC_KEY_CPU_TEMP "TC0P"

--- a/smc.h
+++ b/smc.h
@@ -1,6 +1,6 @@
 /*
  * Apple System Management Control (SMC) Tool
- * Copyright (C) 2006 devnull 
+ * Copyright (C) 2006 devnull
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -46,6 +46,7 @@
 // key values
 #define SMC_KEY_CPU_TEMP "TC0P"
 #define SMC_KEY_GPU_TEMP "TG0P"
+#define SMC_KEY_AMBIENT_TEMP "TA0V"
 #define SMC_KEY_FAN0_RPM_CUR "F0Ac"
 
 typedef struct {

--- a/smc.h
+++ b/smc.h
@@ -19,7 +19,6 @@
 
 #ifndef __SMC_H__
 #define __SMC_H__
-#endif
 
 #define VERSION "0.01"
 
@@ -98,3 +97,5 @@ typedef struct {
 double SMCGetTemperature(char* key);
 kern_return_t SMCSetFanRpm(char* key, int rpm);
 int SMCGetFanRpm(char* key);
+
+#endif

--- a/smc.h
+++ b/smc.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#ifndef __SMC_H__
-#define __SMC_H__
+#ifndef SMC_H
+#define SMC_H
 
 #define VERSION "0.01"
 


### PR DESCRIPTION
* keep default behaviour
* allow optional passing SMC keys
* add options to dump all or individual SMC keys

Reasoning:
There is another PR which proposes to change the default keys read for CPU and GPU. This might not fit everybody (does not for me). So I wanted an option to pass the key that works for me.

`TCXC` as mentioned in https://github.com/lavoiesl/osx-cpu-temp/pull/33 does not work on my older MacBook Pro 2011, but `TC0P` or `TC0D` or `TC0C` work. On a newer MBP 13", the `TC0D` does not work. On my work MBP, the `TC0D` and `TC0C` as well as the `TG0P` and `TG0D` don't work.

To find out what works on a given machine, I added the option to dump all keys.

@lavoiesl : I'm happy to discuss any changes.