### PR TITLE
Fixed error when building 

### DIFF
--- a/smc.c
+++ b/smc.c
@@ -56,7 +56,7 @@ kern_return_t SMCOpen(void)
     io_object_t device;
 
     CFMutableDictionaryRef matchingDictionary = IOServiceMatching("AppleSMC");
-    result = IOServiceGetMatchingServices(kIOMainPortDefault, matchingDictionary, &iterator);
+    result = IOServiceGetMatchingServices(kIOMasterPortDefault, matchingDictionary, &iterator);
     if (result != kIOReturnSuccess) {
         printf("Error: IOServiceGetMatchingServices() = %08x\n", result);
         return 1;


### PR DESCRIPTION
Replaced in "smc.c" "kIOMainPortDefault" - line 59 - with "kIOMasterPortDefault"

If you tried to build with "make", it gave out error, but now it doesn't anymore and works perfectly